### PR TITLE
Page object model

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,10 +36,11 @@ This project is licensed under the MIT License — see the LICENSE file for deta
 
 What would I add next?
 
+Deduplicate and add structure to locators (page object model).
+
 The login page lists a number of different users that result in different UI behaviour such as a locked out user or glitch or other errors. We should try and test those. Some might be as simple as updating the test data for the existing login test, but others would require dedicated tests.
 
 Note: Added locked_out_user test in [e4d073896ba7d4a845a26fb0760bf56286ff9084](https://github.com/MarkJB/Playwright/commit/e4d073896ba7d4a845a26fb0760bf56286ff9084)
- 
 
 We could also do more extensive tests on the cart, adding multiple products, checking totals, removing products and checking totals and qtys update as expected.
 

--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 This is an attempt at quickly creating a test suite for https://saucedemo.com/ (Sauce Labs test demo site).
 
+Updated with a basic Page Object Model.
+
 It was not intended to provide 100% test coverage, but was an exercise in starting from scratch again, re-familiarizing myself with Playwright & Typescript (not that it needed much Typescript - seems to be inferred well enough).
 
 I hit a few Gotchas that I remember hitting in the past like using async inside `.forEach` tests\*, or `map()` with other logic (Note: both `map()` and `[]forEach()` work fine if you are calling `test()` within it in a synchronous way (i.e. not calling it with async - see note below)).
@@ -35,8 +37,6 @@ This project is licensed under the MIT License — see the LICENSE file for deta
 ## Next steps?
 
 What would I add next?
-
-Deduplicate and add structure to locators (page object model).
 
 The login page lists a number of different users that result in different UI behaviour such as a locked out user or glitch or other errors. We should try and test those. Some might be as simple as updating the test data for the existing login test, but others would require dedicated tests.
 

--- a/tests/cart.spec.ts
+++ b/tests/cart.spec.ts
@@ -1,10 +1,8 @@
-import { test, expect } from "@playwright/test";
-import { login, selectProduct } from "../utils/utils";
+import { expect } from "@playwright/test";
+import { login, selectProduct, test } from "../utils/utils";
 import { faker } from "@faker-js/faker";
-import { PageObjectModel } from "../utils/pageObjectModel";
 
-test.beforeEach(async ({ page }) => {
-  const pom = new PageObjectModel(page);
+test.beforeEach(async ({ page, pom }) => {
   // Navigate to the login page before each test
   await page.goto("https://www.saucedemo.com/");
   // Login with default credentials
@@ -59,8 +57,7 @@ const customerInfo = [
 ];
 
 customerInfo.forEach(({ title, firstName, lastName, postalCode, message }) => {
-  test(`Checkout with ${title}`, async ({ page }) => {
-    const pom = new PageObjectModel(page);
+  test(`Checkout with ${title}`, async ({ pom }) => {
     // Fill in the checkout form with the provided customer data
     if (firstName) {
       await pom.cart.firstNameInput().fill(firstName);

--- a/tests/cart.spec.ts
+++ b/tests/cart.spec.ts
@@ -15,13 +15,13 @@ test.beforeEach(async ({ page }) => {
   await selectProduct(page);
 
   // Go to the cart
-  await pom.inventory.shoppingCartLink().click();
+  await pom.inventory.shoppingCartIconButton().click();
 
   // Proceed to checkout
   await pom.cart.checkoutButton().click();
 
   // Verify that the checkout form is displayed
-  await expect(pom.inventory.title()).toHaveText("Checkout: Your Information"); // TODO: Shared locator
+  await expect(pom.cart.title()).toHaveText("Checkout: Your Information");
 });
 
 // After creating a few permutations of the checkout process, it feels like this

--- a/tests/cart.spec.ts
+++ b/tests/cart.spec.ts
@@ -1,27 +1,27 @@
 import { test, expect } from "@playwright/test";
 import { login, selectProduct } from "../utils/utils";
 import { faker } from "@faker-js/faker";
+import { PageObjectModel } from "../utils/pageObjectModel";
 
 test.beforeEach(async ({ page }) => {
+  const pom = new PageObjectModel(page);
   // Navigate to the login page before each test
   await page.goto("https://www.saucedemo.com/");
   // Login with default credentials
   await login(page);
   // Verify that we are on the inventory page
-  await expect(page.locator('[data-test="title"]')).toHaveText("Products");
+  await expect(pom.inventory.title()).toHaveText("Products");
   // Add default product to the cart
   await selectProduct(page);
 
   // Go to the cart
-  await page.locator('[data-test="shopping-cart-link"]').click();
+  await pom.inventory.shoppingCartLink().click();
 
   // Proceed to checkout
-  await page.getByRole("button", { name: "Checkout" }).click();
+  await pom.cart.checkoutButton().click();
 
   // Verify that the checkout form is displayed
-  await expect(page.locator('[data-test="title"]')).toHaveText(
-    "Checkout: Your Information"
-  );
+  await expect(pom.inventory.title()).toHaveText("Checkout: Your Information"); // TODO: Shared locator
 });
 
 // After creating a few permutations of the checkout process, it feels like this
@@ -60,23 +60,23 @@ const customerInfo = [
 
 customerInfo.forEach(({ title, firstName, lastName, postalCode, message }) => {
   test(`Checkout with ${title}`, async ({ page }) => {
+    const pom = new PageObjectModel(page);
     // Fill in the checkout form with the provided customer data
     if (firstName) {
-      await page.getByRole("textbox", { name: "First Name" }).fill(firstName);
+      await pom.cart.firstNameInput().fill(firstName);
     }
     if (lastName) {
-      await page.getByRole("textbox", { name: "Last Name" }).fill(lastName);
+      await pom.cart.lastNameInput().fill(lastName);
     }
     if (postalCode) {
-      await page
-        .getByRole("textbox", { name: "ZIP/Postal Code" })
-        .fill(postalCode);
+      await pom.cart.postalCodeInput().fill(postalCode);
     }
 
     // Submit the form
-    await page.getByRole("button", { name: "Continue" }).click();
+    await pom.cart.continueButton().click();
 
     // Verify that an error message is displayed
-    await expect(page.getByText(message)).toBeVisible();
+    await expect(pom.cart.errorMessage(message)).toBeVisible();
+    // await expect(page.getByText(message)).toBeVisible();
   });
 });

--- a/tests/endToEnd.spec.ts
+++ b/tests/endToEnd.spec.ts
@@ -14,14 +14,14 @@ test("Login, add product to cart and checkout", async ({ page }) => {
   await login(page);
 
   // Verify that we are on the inventory page
-  await expect(pom.inventory.title()).toHaveText("Products"); // TODO: Shared locator
+  await expect(pom.inventory.title()).toHaveText("Products");
 
   // Add a product to the cart (There are two options here, add directly from inventory or from the details page)
   await pom.inventory.productByName("Sauce Labs Backpack").click();
   await pom.inventoryItem.addToCartButton().click();
 
   // Go to the cart
-  await pom.inventory.shoppingCartLink().click(); // TODO: Shared locator
+  await pom.inventory.shoppingCartIconButton().click();
   // note: if these elements were using the custom attribute data-testid,
   // we could use page.getByTestId("shopping-cart-link").click(); instead.
 
@@ -41,7 +41,7 @@ test("Login, add product to cart and checkout", async ({ page }) => {
   await pom.cart.continueButton().click();
 
   // Verify checkout overview (We might want to verify the product details here as well, depends on what is important)
-  await expect(pom.inventory.title()).toHaveText("Checkout: Overview");
+  await expect(pom.cart.title()).toHaveText("Checkout: Overview");
 
   // Complete purchase
   await pom.cart.finishButton().click();

--- a/tests/endToEnd.spec.ts
+++ b/tests/endToEnd.spec.ts
@@ -1,10 +1,8 @@
-import { test, expect } from "@playwright/test";
-import { login } from "../utils/utils";
+import { expect } from "@playwright/test";
+import { login, test } from "../utils/utils";
 import { faker } from "@faker-js/faker";
-import { PageObjectModel } from "../utils/pageObjectModel";
 
-test("Login, add product to cart and checkout", async ({ page }) => {
-  const pom = new PageObjectModel(page);
+test("Login, add product to cart and checkout", async ({ page, pom }) => {
   // Scenario: Can complete a product purchase.
   // Given I am logged in
   // When I add a product to the cart, and proceed to checkout

--- a/tests/inventory.spec.ts
+++ b/tests/inventory.spec.ts
@@ -1,6 +1,5 @@
-import { test, expect } from "@playwright/test";
-import { login, selectProduct } from "../utils/utils";
-import { PageObjectModel } from "../utils/pageObjectModel";
+import { expect } from "@playwright/test";
+import { login, selectProduct, test } from "../utils/utils";
 
 test.beforeEach(async ({ page }) => {
   // Navigate to site and login before each test - should pull credentials from .env file
@@ -9,8 +8,7 @@ test.beforeEach(async ({ page }) => {
 });
 
 test.describe("Products", () => {
-  test("Add Product to cart", async ({ page }) => {
-    const pom = new PageObjectModel(page);
+  test("Add Product to cart", async ({ pom }) => {
     // Scenario: Add a product to the cart and verify it appears in the cart icon
     // Given I am on the inventory (Products) page
     await expect(pom.inventory.title()).toBeVisible(); // Not a great locator as "Products" could appear anywhere in the test - maybe URL would be better.
@@ -31,8 +29,7 @@ test.describe("Products", () => {
     await expect(pom.inventory.shoppingCartIconButton()).toHaveText("1");
   });
 
-  test("Remove Product from cart", async ({ page }) => {
-    const pom = new PageObjectModel(page);
+  test("Remove Product from cart", async ({ pom }) => {
     // Scenario: Remove a product from the cart and verify it disappears from the cart icon
     // Given I am on the inventory page
     await expect(pom.inventory.title()).toHaveText("Products");
@@ -48,8 +45,7 @@ test.describe("Products", () => {
     await expect(pom.inventory.shoppingCartIconButton()).toBeEmpty();
   });
 
-  test("Check default product sort order", async ({ page }) => {
-    const pom = new PageObjectModel(page);
+  test("Check default product sort order", async ({ pom }) => {
     // Scenario: Verify the default product sort order is "Name (A to Z)"
     // Given I am on the inventory page
     await expect(pom.inventory.title()).toHaveText("Products");
@@ -71,8 +67,7 @@ test.describe("Products", () => {
     await expect(productNames).toEqual(sortedProductNames);
   });
 
-  test("Sort products alphanumerically reverse (z-a)", async ({ page }) => {
-    const pom = new PageObjectModel(page);
+  test("Sort products alphanumerically reverse (z-a)", async ({ pom }) => {
     // Scenario: Sort products alphabetically in reverse order (Z to A)"
     // Given I am on the inventory page
     await expect(pom.inventory.title()).toHaveText("Products");
@@ -94,8 +89,7 @@ test.describe("Products", () => {
     ).toEqual(sortedProductNames);
   });
 
-  test("Sort Products by price low to high", async ({ page }) => {
-    const pom = new PageObjectModel(page);
+  test("Sort Products by price low to high", async ({ page, pom }) => {
     // Scenario: Sort products by price from low to high
     // Given I am on the inventory page
     await expect(pom.inventory.title()).toHaveText("Products");
@@ -121,8 +115,7 @@ test.describe("Products", () => {
     }
   });
 
-  test("Sort Products by price high to low", async ({ page }) => {
-    const pom = new PageObjectModel(page);
+  test("Sort Products by price high to low", async ({ pom }) => {
     // Scenario: Sort products by price from high to low
     // Given I am on the inventory page
     await expect(pom.inventory.title()).toHaveText("Products");
@@ -148,8 +141,7 @@ test.describe("Products", () => {
 });
 
 test.describe("Product Details", () => {
-  test("Verify product details", async ({ page }) => {
-    const pom = new PageObjectModel(page);
+  test("Verify product details", async ({ pom }) => {
     // Scenario: Verify product details when clicking on a product
     // Given I am on the inventory page
     await expect(pom.inventory.title()).toHaveText("Products");
@@ -165,8 +157,8 @@ test.describe("Product Details", () => {
 
   test("Check we can get back to the inventory page from a product", async ({
     page,
+    pom,
   }) => {
-    const pom = new PageObjectModel(page);
     // Scenario: Verify we can navigate back to the inventory page from a product
     // Given I am on a product details page
     await selectProduct(page);
@@ -178,8 +170,10 @@ test.describe("Product Details", () => {
     await expect(pom.inventory.title()).toHaveText("Products");
   });
 
-  test("Add product to cart from product details page", async ({ page }) => {
-    const pom = new PageObjectModel(page);
+  test("Add product to cart from product details page", async ({
+    page,
+    pom,
+  }) => {
     // Scenario: Add a product to the cart from the product details page
     // Given I am on a product details page
     await selectProduct(page);
@@ -194,8 +188,8 @@ test.describe("Product Details", () => {
 
   test("Remove product from cart from product details page", async ({
     page,
+    pom,
   }) => {
-    const pom = new PageObjectModel(page);
     // Scenario: Remove a product from the cart from the product details page
     // Given I am on a product details page
     await selectProduct(page);

--- a/tests/inventory.spec.ts
+++ b/tests/inventory.spec.ts
@@ -28,7 +28,7 @@ test.describe("Products", () => {
       testAllTheThingsShirtRed.getByRole("button", { name: "Remove" })
     ).toBeVisible();
     // And the cart icon should show 1 item
-    await expect(pom.inventory.shoppingCartLink()).toHaveText("1");
+    await expect(pom.inventory.shoppingCartIconButton()).toHaveText("1");
   });
 
   test("Remove Product from cart", async ({ page }) => {
@@ -45,7 +45,7 @@ test.describe("Products", () => {
       pom.inventory.addToCartButton("sauce-labs-backpack")
     ).toBeVisible();
     // And the cart icon should show 0 items
-    await expect(pom.inventory.shoppingCartLink()).toBeEmpty();
+    await expect(pom.inventory.shoppingCartIconButton()).toBeEmpty();
   });
 
   test("Check default product sort order", async ({ page }) => {
@@ -187,7 +187,7 @@ test.describe("Product Details", () => {
     await pom.inventoryItem.addToCartButton().click();
     // Then the product should be added to the cart
     // (cart icon should show 1 item)
-    await expect(pom.inventory.shoppingCartLink()).toHaveText("1");
+    await expect(pom.inventoryItem.shoppingCartIconButton()).toHaveText("1");
     // And the "Add to cart" button should change to "Remove"
     await expect(pom.inventoryItem.removeFromCartButton()).toBeVisible();
   });
@@ -205,7 +205,7 @@ test.describe("Product Details", () => {
     await pom.inventoryItem.removeFromCartButton().click();
     // Then the product should be added to the cart
     // (cart icon should show 1 item)
-    await expect(pom.inventory.shoppingCartLink()).toBeEmpty(); // TODO: Shared locator. Shopping cart shows on all pages so could have a shared section that can also be resued in each section for ease of use
+    await expect(pom.inventoryItem.shoppingCartIconButton()).toBeEmpty();
     // And the "Add to cart" button should change to "Add to cart"
     await expect(pom.inventoryItem.addToCartButton()).toBeVisible();
   });

--- a/tests/login.spec.ts
+++ b/tests/login.spec.ts
@@ -1,5 +1,6 @@
 import { test, expect } from "@playwright/test";
 import { login, testLogin } from "../utils/utils";
+import { PageObjectModel } from "../utils/pageObjectModel";
 
 test.describe("Login", () => {
   test.beforeEach(async ({ page }) => {
@@ -12,68 +13,44 @@ test.describe("Login", () => {
   // a single test function. See example at the end of this file.
 
   test("Login with valid credentials", async ({ page }) => {
-    // Fill in the username and password fields
-
-    // Compare the Codegen suggested locator vs an accessible locator
-    // await page.fill("#user-name", "standard_user");
-    // await page.fill("#password", "secret_sauce");
-    await page.getByRole("textbox", { name: "Username" }).fill("standard_user");
-    await page.getByRole("textbox", { name: "Password" }).fill("secret_sauce");
-    // Click the login button
-    // await page.click("#login-button");
-    await page.getByRole("button", { name: "Login" }).click();
-    // Verify that the login was successful by checking for the presence of the inventory page
-    //   await expect(page.getByRole("heading", { name: "Products" })).toBeVisible();
-    await expect(page.locator("[data-test='title']")).toHaveText("Products");
+    const pom = new PageObjectModel(page);
+    await pom.login.usernameInput().fill("standard_user");
+    await pom.login.passwordInput().fill("secret_sauce");
+    await pom.login.loginButton().click();
+    await expect(pom.inventory.title()).toHaveText("Products");
   });
 
   test("Login with invalid username", async ({ page }) => {
-    // Fill in the username and password fields with invalid username
-    await page.getByRole("textbox", { name: "Username" }).fill("invalid_user");
-    await page.getByRole("textbox", { name: "Password" }).fill("secret_sauce");
-
-    // Click the login button
-    await page.getByRole("button", { name: "Login" }).click();
-
-    // Verify that the error message is displayed
+    const pom = new PageObjectModel(page);
+    await pom.login.usernameInput().fill("invalid_user");
+    await pom.login.passwordInput().fill("secret_sauce");
+    await pom.login.loginButton().click();
     await expect(
-      page.getByText(
+      pom.login.errorMessage(
         "Epic sadface: Username and password do not match any user in this service"
       )
     ).toBeVisible();
   });
 
   test("Login with invalid password", async ({ page }) => {
-    // Fill in the username and password fields with invalid password
-    await page.getByRole("textbox", { name: "Username" }).fill("standard_user");
-    await page
-      .getByRole("textbox", { name: "Password" })
-      .fill("invalid_password");
-
-    // Click the login button
-    await page.getByRole("button", { name: "Login" }).click();
-
-    // Verify that the error message is displayed
+    const pom = new PageObjectModel(page);
+    await pom.login.usernameInput().fill("standard_user");
+    await pom.login.passwordInput().fill("invalid_password");
+    await pom.login.loginButton().click();
     await expect(
-      page.getByText(
+      pom.login.errorMessage(
         "Epic sadface: Username and password do not match any user in this service"
       )
     ).toBeVisible();
   });
 
   test("Login with both invalid username and password", async ({ page }) => {
-    // Fill in the username and password fields with invalid credentials
-    await page.getByRole("textbox", { name: "Username" }).fill("invalid_user");
-    await page
-      .getByRole("textbox", { name: "Password" })
-      .fill("invalid_password");
-
-    // Click the login button
-    await page.getByRole("button", { name: "Login" }).click();
-
-    // Verify that the error message is displayed
+    const pom = new PageObjectModel(page);
+    await pom.login.usernameInput().fill("invalid_user");
+    await pom.login.passwordInput().fill("invalid_password");
+    await pom.login.loginButton().click();
     await expect(
-      page.getByText(
+      pom.login.errorMessage(
         "Epic sadface: Username and password do not match any user in this service"
       )
     ).toBeVisible();
@@ -124,15 +101,10 @@ test.describe("Parametrized Login Tests", () => {
     }) => {
       // We can replace all of this with the login utility function
       login(page, username, password);
-      //   // Fill in the username and password fields with locked out user credentials
-      //   await page.getByRole("textbox", { name: "Username" }).fill(username);
-      //   await page.getByRole("textbox", { name: "Password" }).fill(password);
-
-      //   // Click the login button
-      //   await page.getByRole("button", { name: "Login" }).click();
 
       // Verify that the expected message is displayed
-      await expect(page.getByText(expected)).toBeVisible();
+      const pom = new PageObjectModel(page);
+      await expect(pom.login.errorMessage(expected)).toBeVisible();
     });
   });
 });

--- a/tests/login.spec.ts
+++ b/tests/login.spec.ts
@@ -1,6 +1,6 @@
-import { test, expect } from "@playwright/test";
-import { login, testLogin } from "../utils/utils";
-import { PageObjectModel } from "../utils/pageObjectModel";
+// import { test, expect } from "@playwright/test";
+import { expect } from "@playwright/test";
+import { login, test } from "../utils/utils";
 
 test.describe("Login", () => {
   test.beforeEach(async ({ page }) => {
@@ -12,16 +12,14 @@ test.describe("Login", () => {
   // We could create an array with the username, password, and expected results, passing that to
   // a single test function. See example at the end of this file.
 
-  test("Login with valid credentials", async ({ page }) => {
-    const pom = new PageObjectModel(page);
+  test("Login with valid credentials", async ({ pom }) => {
     await pom.login.usernameInput().fill("standard_user");
     await pom.login.passwordInput().fill("secret_sauce");
     await pom.login.loginButton().click();
     await expect(pom.inventory.title()).toHaveText("Products");
   });
 
-  test("Login with invalid username", async ({ page }) => {
-    const pom = new PageObjectModel(page);
+  test("Login with invalid username", async ({ pom }) => {
     await pom.login.usernameInput().fill("invalid_user");
     await pom.login.passwordInput().fill("secret_sauce");
     await pom.login.loginButton().click();
@@ -32,8 +30,7 @@ test.describe("Login", () => {
     ).toBeVisible();
   });
 
-  test("Login with invalid password", async ({ page }) => {
-    const pom = new PageObjectModel(page);
+  test("Login with invalid password", async ({ pom }) => {
     await pom.login.usernameInput().fill("standard_user");
     await pom.login.passwordInput().fill("invalid_password");
     await pom.login.loginButton().click();
@@ -44,8 +41,7 @@ test.describe("Login", () => {
     ).toBeVisible();
   });
 
-  test("Login with both invalid username and password", async ({ page }) => {
-    const pom = new PageObjectModel(page);
+  test("Login with both invalid username and password", async ({ pom }) => {
     await pom.login.usernameInput().fill("invalid_user");
     await pom.login.passwordInput().fill("invalid_password");
     await pom.login.loginButton().click();
@@ -98,50 +94,13 @@ test.describe("Parametrized Login Tests", () => {
   testData.forEach(({ username, password, expected }) => {
     test(`Login; Username: ${username}, Password: ${password}, Expectation: ${expected}`, async ({
       page,
+      pom,
     }) => {
       // We can replace all of this with the login utility function
       login(page, username, password);
 
       // Verify that the expected message is displayed
-      const pom = new PageObjectModel(page);
       await expect(pom.login.errorMessage(expected)).toBeVisible();
     });
   });
 });
-
-// This is the first time I've used fixtures in Playwright.
-// It is a bit different than pytest...
-// The testLogin fixture is defined in the utils/utils.ts file.
-// It uses the login utility function to log in before each test.
-// It is called `testLogin` and is an extension of the base `test`. (Like `'test' but with a `page` that is already logged in`)
-// Instead of providing a `page` to the test, we provide an `authenticatedPage` that is already logged in.
-// We override the default `userCredentials` with testLogin.use(). It is expecting an object with `username` and `password` properties.
-// The `authenticatedPage` is passed to the test function, which can be used to interact with the browser page as usual.
-
-// How does this compare with test.beforeEach and calling utility functions?
-// It's more opaque. Does it cut down on boilerplate code?
-
-// Note: We could make testData a fixture as well.
-
-// Ok this didn't work. Turns out that testLogin.use() will override the data for all tests, no matter where they are running.
-// Put another way, the data is not scoped to the test, but to the entire test suite. So this doesn't work.
-// More correct to say this is not the right use for fixtures or perhaps, not the right way to use fixtures.
-
-// test.describe("Login using fixtures", () => {
-//   test.beforeEach(async ({ page }) => {
-//     // Navigate to the login page before each test
-//     await page.goto("https://www.saucedemo.com/");
-//   });
-//   testData.forEach(({ username, password, expected }) => {
-//     testLogin.use({
-//       userCredentials: { username, password },
-//     });
-//     testLogin(
-//       `Login; Username: ${username}, Password: ${password}, Expectation: ${expected}`,
-//       async ({ authenticatedPage }) => {
-//         // Verify that the expected message is displayed
-//         await expect(authenticatedPage.getByText(expected)).toBeVisible();
-//       }
-//     );
-//   });
-// });

--- a/utils/pageObjectModel.ts
+++ b/utils/pageObjectModel.ts
@@ -13,7 +13,7 @@ export class PageObjectModel {
   };
 
   login = {
-    title: this.common.title,
+    title: () => this.common.title(),
     usernameInput: () => this.page.getByRole("textbox", { name: "Username" }),
     passwordInput: () => this.page.getByRole("textbox", { name: "Password" }),
     loginButton: () => this.page.getByRole("button", { name: "Login" }),
@@ -21,8 +21,8 @@ export class PageObjectModel {
   };
 
   inventory = {
-    title: this.common.title,
-    shoppingCartIconButton: this.common.shoppingCartIconButton,
+    title: () => this.common.title(),
+    shoppingCartIconButton: () => this.common.shoppingCartIconButton(),
     productSortDropdown: () =>
       this.page.locator('[data-test="product-sort-container"]'),
     productNameList: () => this.page.locator(".inventory_item_name"),
@@ -35,8 +35,8 @@ export class PageObjectModel {
   };
 
   inventoryItem = {
-    title: this.common.title,
-    shoppingCartIconButton: this.common.shoppingCartIconButton,
+    title: () => this.common.title(),
+    shoppingCartIconButton: () => this.common.shoppingCartIconButton(),
     // Product details
     addToCartButton: () =>
       this.page.getByRole("button", { name: "Add to cart" }),
@@ -50,7 +50,7 @@ export class PageObjectModel {
   };
 
   cart = {
-    title: this.common.title,
+    title: () => this.common.title(),
     shoppingCartLink: () =>
       this.page.locator('[data-test="shopping-cart-link"]'),
     checkoutButton: () => this.page.getByRole("button", { name: "Checkout" }),

--- a/utils/pageObjectModel.ts
+++ b/utils/pageObjectModel.ts
@@ -1,0 +1,71 @@
+import { Page, Locator } from "@playwright/test";
+
+export class PageObjectModel {
+  constructor(private page: Page) {}
+
+  login = {
+    usernameInput: () => this.page.getByRole("textbox", { name: "Username" }),
+    passwordInput: () => this.page.getByRole("textbox", { name: "Password" }),
+    loginButton: () => this.page.getByRole("button", { name: "Login" }),
+    errorMessage: (text: string) => this.page.getByText(text),
+  };
+
+  inventory = {
+    title: () => this.page.locator('[data-test="title"]'),
+    productSortDropdown: () =>
+      this.page.locator('[data-test="product-sort-container"]'),
+    productNameList: () => this.page.locator(".inventory_item_name"),
+    productPriceList: () => this.page.locator(".inventory_item_price"),
+    addToCartButton: (productId: string) =>
+      this.page.locator(`[data-test="add-to-cart-${productId}"]`),
+    removeFromCartButton: (productId: string) =>
+      this.page.locator(`[data-test="remove-${productId}"]`),
+    shoppingCartLink: () =>
+      this.page.locator('[data-test="shopping-cart-link"]'),
+    productByName: (name: string) => this.page.getByText(name),
+  };
+
+  inventoryItem = {
+    // Product details
+    addToCartButton: () =>
+      this.page.getByRole("button", { name: "Add to cart" }),
+    removeFromCartButton: () =>
+      this.page.getByRole("button", { name: "Remove" }),
+    name: () => this.page.locator(".inventory_details_name"),
+    description: () => this.page.locator(".inventory_details_desc"),
+    price: () => this.page.locator(".inventory_details_price"),
+    backToProductsButton: () =>
+      this.page.locator('[data-test="back-to-products"]'),
+  };
+
+  cart = {
+    shoppingCartLink: () =>
+      this.page.locator('[data-test="shopping-cart-link"]'),
+    checkoutButton: () => this.page.getByRole("button", { name: "Checkout" }),
+    // Checkout form
+    firstNameInput: () =>
+      this.page.getByRole("textbox", { name: "First Name" }),
+    lastNameInput: () => this.page.getByRole("textbox", { name: "Last Name" }),
+    postalCodeInput: () =>
+      this.page.getByRole("textbox", { name: "ZIP/Postal Code" }),
+    continueButton: () => this.page.getByRole("button", { name: "Continue" }),
+    overviewTitle: () => this.page.locator('[data-test="title"]'),
+    finishButton: () => this.page.getByRole("button", { name: "Finish" }),
+    completeHeader: () => this.page.locator('[data-test="complete-header"]'),
+    completeText: () => this.page.locator('[data-test="complete-text"]'),
+    errorMessage: (text: string) => this.page.getByText(text),
+  };
+
+  navigation = {
+    openMenuButton: () => this.page.getByRole("button", { name: "Open Menu" }),
+    closeMenuButton: () =>
+      this.page.getByRole("button", { name: "Close Menu" }),
+    menuItem: (dataTestId: string) =>
+      this.page.locator(`[data-test="${dataTestId}"]`),
+    // Menu items
+    allItems: () => this.page.locator('[data-test="inventory-sidebar-link"]'),
+    about: () => this.page.locator('[data-test="about-sidebar-link"]'),
+    logout: () => this.page.locator('[data-test="logout-sidebar-link"]'),
+    resetAppState: () => this.page.locator('[data-test="reset-sidebar-link"]'),
+  };
+}

--- a/utils/pageObjectModel.ts
+++ b/utils/pageObjectModel.ts
@@ -1,9 +1,19 @@
 import { Page, Locator } from "@playwright/test";
 
 export class PageObjectModel {
-  constructor(private page: Page) {}
+  private page: Page;
+  constructor(page: Page) {
+    this.page = page;
+  }
+
+  common = {
+    title: () => this.page.locator('[data-test="title"]'),
+    shoppingCartIconButton: () =>
+      this.page.locator('[data-test="shopping-cart-link"]'),
+  };
 
   login = {
+    title: this.common.title,
     usernameInput: () => this.page.getByRole("textbox", { name: "Username" }),
     passwordInput: () => this.page.getByRole("textbox", { name: "Password" }),
     loginButton: () => this.page.getByRole("button", { name: "Login" }),
@@ -11,7 +21,8 @@ export class PageObjectModel {
   };
 
   inventory = {
-    title: () => this.page.locator('[data-test="title"]'),
+    title: this.common.title,
+    shoppingCartIconButton: this.common.shoppingCartIconButton,
     productSortDropdown: () =>
       this.page.locator('[data-test="product-sort-container"]'),
     productNameList: () => this.page.locator(".inventory_item_name"),
@@ -20,12 +31,12 @@ export class PageObjectModel {
       this.page.locator(`[data-test="add-to-cart-${productId}"]`),
     removeFromCartButton: (productId: string) =>
       this.page.locator(`[data-test="remove-${productId}"]`),
-    shoppingCartLink: () =>
-      this.page.locator('[data-test="shopping-cart-link"]'),
     productByName: (name: string) => this.page.getByText(name),
   };
 
   inventoryItem = {
+    title: this.common.title,
+    shoppingCartIconButton: this.common.shoppingCartIconButton,
     // Product details
     addToCartButton: () =>
       this.page.getByRole("button", { name: "Add to cart" }),
@@ -39,6 +50,7 @@ export class PageObjectModel {
   };
 
   cart = {
+    title: this.common.title,
     shoppingCartLink: () =>
       this.page.locator('[data-test="shopping-cart-link"]'),
     checkoutButton: () => this.page.getByRole("button", { name: "Checkout" }),

--- a/utils/utils.ts
+++ b/utils/utils.ts
@@ -48,3 +48,11 @@ export const selectProduct = async (
   await page.getByText(product).click();
   await expect(pom.inventoryItem.name()).toHaveText("Sauce Labs Backpack");
 };
+
+// Make the Page Object Model available to all tests that use this fixture
+// (saves having to instantiate it in each test)
+export const test = base.extend<{ pom: PageObjectModel }>({
+  pom: async ({ page }, use) => {
+    await use(new PageObjectModel(page));
+  },
+});

--- a/utils/utils.ts
+++ b/utils/utils.ts
@@ -1,4 +1,5 @@
 import { expect, Page, test as base } from "@playwright/test";
+import { PageObjectModel } from "./pageObjectModel";
 
 // These could be made into fixtures... Lets duplicate them and provide both utils and fixtures
 
@@ -8,12 +9,13 @@ export const login = async (
   username: string = "standard_user",
   password: string = "secret_sauce"
 ) => {
+  const pom = new PageObjectModel(page);
   // Fill in the username and password fields with locked out user credentials
-  await page.getByRole("textbox", { name: "Username" }).fill(username);
-  await page.getByRole("textbox", { name: "Password" }).fill(password);
+  await pom.login.usernameInput().fill(username);
+  await pom.login.passwordInput().fill(password);
 
   // Click the login button
-  await page.getByRole("button", { name: "Login" }).click();
+  await pom.login.loginButton().click();
 };
 
 // login fixture
@@ -39,11 +41,10 @@ export const selectProduct = async (
   page: Page,
   product: string | undefined = "Sauce Labs Backpack"
 ) => {
+  const pom = new PageObjectModel(page);
   // Helper function to select a product from the products inventory page
   // (don't forget to call this function with await or your test will not wait for it to complete)
-  await expect(page.locator('[data-test="title"]')).toHaveText("Products");
+  await expect(pom.inventory.title()).toHaveText("Products");
   await page.getByText(product).click();
-  await expect(page.locator('[data-test="inventory-item-name"]')).toHaveText(
-    "Sauce Labs Backpack"
-  );
+  await expect(pom.inventoryItem.name()).toHaveText("Sauce Labs Backpack");
 };


### PR DESCRIPTION
Add a Page Object Model for the locators.

All this to a `test` fixture so when we import that instead of the default playwright provided `test` we will automatically have a `pom` instance we can use to access the known locators.

Some locators are shared and are made available in a `.common` object, but also within each page object that would also require those locators e.g. `.common.title()` and `.inventory.title()`

Organization may not be perfect, but this is just intended as a demonstration.